### PR TITLE
updating media types to "+json" convention

### DIFF
--- a/json-home/draft-nottingham-json-home-03.xml
+++ b/json-home/draft-nottingham-json-home-03.xml
@@ -63,7 +63,7 @@ interpreted as described in <xref target="RFC2119"/>.</t>
     </section>
     <section anchor="json-home-documents" title="JSON Home Documents">
       <t>A JSON Home Document uses the format described in <xref target="RFC4627"/> and has the
-media type “application/json-home”.</t>
+media type “application/home+json”.</t>
       <t>Its content consists of a root object with a “resources” property, whose
 member names are link relation types (as defined by <xref target="RFC5988"/>), and values
 are Resource Objects, defined below.</t>
@@ -72,10 +72,10 @@ are Resource Objects, defined below.</t>
         <artwork><![CDATA[
   GET / HTTP/1.1
   Host: example.org
-  Accept: application/json-home
+  Accept: application/home+json
 
   HTTP/1.1 200 OK
-  Content-Type: application/json-home
+  Content-Type: application/home+json
   Cache-Control: max-age=3600
   Connection: close
 
@@ -94,7 +94,7 @@ are Resource Objects, defined below.</t>
           "formats": {
             "application/json": {}
           },
-          "accept-patch": ["application/json-patch"],
+          "accept-patch": ["application/json-patch+json"],
           "accept-post": ["application/xml"],
           "accept-ranges": ["bytes"]
         }
@@ -177,7 +177,7 @@ global identifiers for the semantics and syntax of those variables.</t>
       "formats": {
         "application/json": {}
       },
-      "accept-patch": ["application/json-patch"],
+      "accept-patch": ["application/json-patch+json"],
       "accept-post": ["application/xml"],
       "accept-ranges": ["bytes"]
     }


### PR DESCRIPTION
i am getting comments on the name difference between the XML media type and the JSON media type. the idea is to adopt the +json convention, right? also, i fixed the JSON Patch media type name in the example.
