### PR TITLE
Dealing with a truncation attack

### DIFF
--- a/http-encryption-encoding/draft.md
+++ b/http-encryption-encoding/draft.md
@@ -135,7 +135,8 @@ agility is achieved by defining a new content-coding scheme.  This ensures that 
 Accept-Encoding header field is necessary to negotiate the use of encryption.
 
 The "aesgcm-128" content-coding uses a fixed record size.  The resulting encoding is a series of
-fixed-size records, though the final record can contain any amount of data.
+fixed-size records, with a final record that is one or more octets shorter than a fixed sized
+record.
 
 ~~~
        +------+
@@ -172,8 +173,14 @@ network byte order.  Records are indexed starting at zero.
 
 The additional data passed to the AEAD algorithm is a zero-length octet sequence.
 
+A sequence of full-sized records can be truncated to produce a shorter sequence of records with
+valid authentication tags.  To prevent an attacker from truncating a stream, an endoder MUST append
+a record that contains only padding if the final record is not shorter than the record size.  A
+receiver MUST treat the stream as failed due to truncation if the final record is not less than the
+full record size.
+
 Issue:
-: Double check that having no AAD is safe.
+: Double check that this construction (with no AAD) is safe.
 
 
 # The "Encryption" HTTP header field  {#encryption}


### PR DESCRIPTION
@ekr pointed this nasty one out before.  An attacker can easily truncate a series of records at the record boundary and the receiver will accept them.  That's bad.

Since HTTP helps us determine the length, the cheapest approach is to require a non-full-sized record at the end of the full sequence.

@ekr finds this solution a little disgusting, but it is more byte-efficient than most of the alternatives he could suggest.  The only option that doesn't spend extra bits is where you change the AAD for the last block.  That has the cost of forcing either a trial decryption or a read-ahead for indefinite length encodings, which is worse in my opinion (it also weakens the authentication tag by a bit, but I won't lose sleep over that).  Other options all steal from the padding byte, reducing the amount of padding we can describe, unless we increase the number of bytes spent on padding.

Closes #108.