### PR TITLE
minor addition (mentioning the second "extension example")

### DIFF
--- a/http-problem/draft-ietf-appsawg-http-problem-01.xml
+++ b/http-problem/draft-ietf-appsawg-http-problem-01.xml
@@ -266,7 +266,8 @@ Content-Language: en
         
         <t>For example, our "out of credit" problem above defines two such
           extensions, "balance" and "accounts" to convey additional, 
-          problem-specific information.</t>
+          problem-specific information. The "validation error" problem
+          defines an additional "invalid-params" member.</t>
 
         <t>Clients consuming problem details MUST ignore any such extensions
         that they don't recognise; this allows problem types to evolve and


### PR DESCRIPTION
would be worthwhile to also add the "validation error" example to the XML section?