### PR TITLE
[h2-cache-digest] Gcs fixes

### DIFF
--- a/h2-cache-digest/draft.md
+++ b/h2-cache-digest/draft.md
@@ -137,8 +137,8 @@ To compute a digest-value for the set `URLs` and `P`:
 7. Write `N` and `P` to `digest` as unsigned long integers.
 8. For each `V` in `hash-values`:
     1. Let `W` be the value following `V` in `hash-values`.
-    2. Let `D` be the result of `W - V`.
-    3. If `D` is 0, continue to the next `V`.
+    2. If `W` and `V` are equal, continue to the next `V`.
+    3. Let `D` be the result of `W - V - 1`.
     4. Let `Q` be the integer result of `D / P`.
     5. Let `R` be the result of `D modulo P`.
     6. Write `Q` '1' bits to `digest`.

--- a/h2-cache-digest/draft.md
+++ b/h2-cache-digest/draft.md
@@ -125,7 +125,7 @@ to tolerate, expressed as `1/P`.
 
 To compute a digest-value for the set `URLs` and `P`:
 
-1. Let N be the count of `URLs`' members.
+1. Let N be the count of `URLs`' members, rounded up to power of 2.
 2. Let `hash-values` be an empty array of integers.
 3. Append 0 to `hash-values`.
 4. For each `URL` in URLs, follow these steps:
@@ -134,7 +134,7 @@ To compute a digest-value for the set `URLs` and `P`:
     3. Append `key` modulo ( `N` * `P` ) to `hash-values`.
 5. Sort `hash-values` in ascending order.
 6. Let `digest` be an empty array of bits.
-7. Write `N` and `P` to `digest` as unsigned long integers.
+7. Write log base 2 of `N` and `P` to `digest` as octets.
 8. For each `V` in `hash-values`:
     1. Let `W` be the value following `V` in `hash-values`.
     2. If `W` and `V` are equal, continue to the next `V`.

--- a/h2-cache-digest/draft.md
+++ b/h2-cache-digest/draft.md
@@ -145,7 +145,7 @@ To compute a digest-value for the set `URLs` and `P`:
     7. Write 1 '0' bit to `digest`.
     8. Write `R` to `digest` as binary, using log2(P) bits.
     9. If `V` is the second-to-last member of `hash-values`, stop iterating through `hash-values` and continue to the next step.
-9. If the length of `digest` is not a multiple of 8, pad it with 0s until it is.
+9. If the length of `digest` is not a multiple of 8, pad it with 1s until it is.
 
 
 # IANA Considerations


### PR DESCRIPTION
This PR consists of three commits to h2-cache-digest.

The first commit (marked _bugfix_) is mandatory.  The other two commits (marked _improvement_) are not, but they simplify the logic as well as minimizes amount of data being transferred.