### PR TITLE
Refine the calculation of GCS

### DIFF
--- a/h2-cache-digest/draft.md
+++ b/h2-cache-digest/draft.md
@@ -121,21 +121,23 @@ A client MAY choose a subset of the available stored responses to include in the
 it MUST choose a parameter, `P`, that indicates the probability of a false positive it is willing
 to tolerate, expressed as `1/P`.
 
-`P` MUST be a power of 2.
+`P` MUST be a power of 2, smaller than 2**32.
 
 To compute a digest-value for the set `URLs` and `P`:
 
-1. Let N be the count of `URLs`' members, rounded up to power of 2.
+1. Let N be the count of `URLs`' members, rounded up to power of 2.  If N is above 2**32, then let N be 2**31.
 2. Let `hash-values` be an empty array of integers.
 3. Append 0 to `hash-values`.
 4. For each `URL` in URLs, follow these steps:
     1. Convert `URL` to an ASCII string by percent-encoding as appropriate {{RFC3986}}.
     2. Let `key` be the SHA-256 message digest {{RFC6234}} of URL, expressed as an integer.
-    3. Append `key` modulo ( `N` * `P` ) to `hash-values`.
+    3. Truncate `key` to log2( `N` * `P` ) bits.
+    4. Append `key` to `hash-values`.
 5. Sort `hash-values` in ascending order.
 6. Let `digest` be an empty array of bits.
-7. Write log base 2 of `N` and `P` to `digest` as octets.
-8. For each `V` in `hash-values`:
+7. Write log base 2 of `N` to `digest` using 5 bits.
+8. Write log base 2 of `P` to `digest` using 5 bits.
+9. For each `V` in `hash-values`:
     1. Let `W` be the value following `V` in `hash-values`.
     2. If `W` and `V` are equal, continue to the next `V`.
     3. Let `D` be the result of `W - V - 1`.
@@ -145,7 +147,7 @@ To compute a digest-value for the set `URLs` and `P`:
     7. Write 1 '0' bit to `digest`.
     8. Write `R` to `digest` as binary, using log2(P) bits.
     9. If `V` is the second-to-last member of `hash-values`, stop iterating through `hash-values` and continue to the next step.
-9. If the length of `digest` is not a multiple of 8, pad it with 1s until it is.
+10. If the length of `digest` is not a multiple of 8, pad it with 1s until it is.
 
 
 # IANA Considerations


### PR DESCRIPTION
This PR makes small changes to how the GCS is calculated, specifically:

- truncate the hash value (instead of calculating the modulo)
- emit N and P in 5 bits, so that `hash-values` can always be represented using a 64-bit value type
- split the emissions of N and P to separate steps to avoid confusion

The changes were suggested by Martin Thomson (https://lists.w3.org/Archives/Public/ietf-http-wg/2016JanMar/0026.html), and Alex Rousskov (https://lists.w3.org/Archives/Public/ietf-http-wg/2016JanMar/0025.html).