### PR TITLE
padding must be the unterminated q-part of the encoded value

### DIFF
--- a/h2-cache-digest/draft.md
+++ b/h2-cache-digest/draft.md
@@ -186,7 +186,7 @@ Given the following inputs:
     7. Write 1 '1' bit to `digest-value`.
     8. Write `R` to `digest-value` as binary, using log2(P) bits.
     9. If `V` is the second-to-last member of `hash-values`, stop iterating through `hash-values` and continue to the next step.
-10. If the length of `digest-value` is not a multiple of 8, pad it with 1s until it is.
+10. If the length of `digest-value` is not a multiple of 8, pad it with 0s until it is.
 
 
 


### PR DESCRIPTION
The bits used in the unary encoding has been reversed in b276101.  That means that we should also reverse the bits used for the padding.

The padding needs to be a partial q-part of the encoded value, or a decoder might erroneously decode values from the padding.