### PR TITLE
Fix misuses of `stale`

### DIFF
--- a/h2-cache-digest/draft.md
+++ b/h2-cache-digest/draft.md
@@ -113,7 +113,7 @@ as effectively clearing all stored digests for that origin.
 A client can indicate what responses it has fresh in cache by sending one or more CACHE_DIGESTs
 with the STALE flag unset. when all such CACHE_DIGESTs sent since the start of the connection (or
 the last CACHE_DIGEST of any kind with a RESET flag) represent the complete state of fresh cached
-responses for the origin, the client SHOULD indicate that with the COMPLETE flag on the last STALE
+responses for the origin, the client SHOULD indicate that with the COMPLETE flag on the last fresh
 CACHE_DIGEST. Note that this does not need to include any responses cached since the beginning of
 the connection or sending of the RESET flag, as appropriate.
 
@@ -121,7 +121,7 @@ Likewise, a client can indicate what responses it has stale in cache by sending 
 CACHE_DIGESTs with the STALE flag set. When all such CACHE_DIGESTs sent since the start of the
 connection (or since the last CACHE_DIGEST of any kind with a RESET flag) represent the complete
 state of stale cached responses for the origin, the client SHOULD indicate that with the COMPLETE
-flag on the last STALE CACHE_DIGEST, with the same caveats as above.
+flag on the last stale CACHE_DIGEST, with the same caveats as above.
 
 CACHE_DIGEST can be computed to include cached responses' ETags, as indicated by the VALIDATORS
 flag. This information can be used by servers to decide what kinds of responses to push to clients;


### PR DESCRIPTION
The first paragraph discusses about fresh digests.

The second paragraph _is_ discussing about stale digests.  But when we say `last STALE CACHE_DIGEST`, `STALE` doesn't refer to the flag defined in the CACHE_DIGEST frame.  It rather refers to the term defined in RFC 7234.  Therefore, it might be better to spell them in lowercase.