### PR TITLE
Fix encoder issues in h2-cache-digest-01

### DIFF
--- a/h2-cache-digest/draft.md
+++ b/h2-cache-digest/draft.md
@@ -157,22 +157,21 @@ Given the following inputs:
 
 1. Let N be the count of `URLs`' members, rounded to the nearest power of 2 smaller than 2\*\*32.
 2. Let `hash-values` be an empty array of integers.
-3. Append -1 to `hash-values`.
-4. For each (`URL`, `ETag`) in `URLs`, compute a hash value ({{hash}}) and append the result to `hash-values`.
-5. Sort `hash-values` in ascending order.
-6. Let `digest-value` be an empty array of bits.
-7. Write log base 2 of `N` to `digest-value` using 5 bits.
-8. Write log base 2 of `P` to `digest-value` using 5 bits.
+3. For each (`URL`, `ETag`) in `URLs`, compute a hash value ({{hash}}) and append the result to `hash-values`.
+4. Sort `hash-values` in ascending order.
+5. Let `digest-value` be an empty array of bits.
+6. Write log base 2 of `N` to `digest-value` using 5 bits.
+7. Write log base 2 of `P` to `digest-value` using 5 bits.
+8. Let `C` be -1.
 9. For each `V` in `hash-values`:
-    1. Let `W` be the value following `V` in `hash-values`.
-    2. If `W` and `V` are equal, continue to the next `V`.
-    3. Let `D` be the result of `W - V - 1`.
-    4. Let `Q` be the integer result of `D / P`.
-    5. Let `R` be the result of `D modulo P`.
-    6. Write `Q` '0' bits to `digest-value`.
-    7. Write 1 '1' bit to `digest-value`.
-    8. Write `R` to `digest-value` as binary, using log2(`P`) bits.
-    9. If `V` is the second-to-last member of `hash-values`, stop iterating through `hash-values` and continue to the next step.
+    1. If `V` is equal to `C`, continue to the next `V`.
+    2. Let `D` be the result of `W - C - 1`.
+    3. Let `Q` be the integer result of `D / P`.
+    4. Let `R` be the result of `D modulo P`.
+    5. Write `Q` '0' bits to `digest-value`.
+    6. Write 1 '1' bit to `digest-value`.
+    7. Write `R` to `digest-value` as binary, using log2(`P`) bits.
+    8. Let `C` be `V`
 10. If the length of `digest-value` is not a multiple of 8, pad it with 0s until it is.
 
 

--- a/h2-cache-digest/draft.md
+++ b/h2-cache-digest/draft.md
@@ -157,7 +157,7 @@ Given the following inputs:
 
 1. Let N be the count of `URLs`' members, rounded to the nearest power of 2 smaller than 2\*\*32.
 2. Let `hash-values` be an empty array of integers.
-3. Append 0 to `hash-values`.
+3. Append -1 to `hash-values`.
 4. For each (`URL`, `ETag`) in `URLs`, compute a hash value ({{hash}}) and append the result to `hash-values`.
 5. Sort `hash-values` in ascending order.
 6. Let `digest-value` be an empty array of bits.

--- a/h2-cache-digest/draft.md
+++ b/h2-cache-digest/draft.md
@@ -171,7 +171,7 @@ Given the following inputs:
     5. Let `R` be the result of `D modulo P`.
     6. Write `Q` '0' bits to `digest-value`.
     7. Write 1 '1' bit to `digest-value`.
-    8. Write `R` to `digest-value` as binary, using log2(`P`5) bits.
+    8. Write `R` to `digest-value` as binary, using log2(`P`) bits.
     9. If `V` is the second-to-last member of `hash-values`, stop iterating through `hash-values` and continue to the next step.
 10. If the length of `digest-value` is not a multiple of 8, pad it with 0s until it is.
 

--- a/h2-cache-digest/draft.md
+++ b/h2-cache-digest/draft.md
@@ -165,7 +165,7 @@ Given the following inputs:
 8. Let `C` be -1.
 9. For each `V` in `hash-values`:
     1. If `V` is equal to `C`, continue to the next `V`.
-    2. Let `D` be the result of `W - C - 1`.
+    2. Let `D` be the result of `V - C - 1`.
     3. Let `Q` be the integer result of `D / P`.
     4. Let `R` be the result of `D modulo P`.
     5. Write `Q` '0' bits to `digest-value`.


### PR DESCRIPTION
@tatsuhiro-t has found following two issues in the encoding process described in h2-cache-digest-01.

Change `log2("P"5) bits` to `log2("P") bits`. It's unclear why but an unnecessary character `5` has somehow crept into the draft. Commit a997046 removes it.

Off-by-one error between the coder and encoder. This is because the smallest hash value being encoded by the described process is `hashvalue - 1`, whereas the decoder expects the value to be `hashvalue`. This is obviously a bug in the encoding process. In step 3, the smallest value inserted to `hash-values` should have been `-1`, but the draft errorneously specified it to be `0` (note that without it being specified as `-1`, it is impossible to encode a hash-value of zero).

Commit 7a39203 is a minimal fix to the issue. Commit 1e1d6f2 refactors the algorithm for simplicity at the same time achieving more commonality with the decoding process being described.

@tatsuhiro-t could you please take a look to see if these fixes resolve your issues?