### PR TITLE
Reference CORS spec in place of Fetch

### DIFF
--- a/bcp56bis/draft.md
+++ b/bcp56bis/draft.md
@@ -333,7 +333,7 @@ caveats to keep in mind:
 
 * Features that rely upon the URL's origin {{?RFC6454}}, such as the Web's same-origin policy, will be impacted by a change of scheme.
 
-* HTTP-specific features such as cookies {{?RFC6265}}, authentication {{?RFC7235}}, caching {{?RFC7234}}, and CORS {{FETCH}} might or might not work correctly, depending on how they are defined and implemented. Generally, they are designed and implemented with an assumption that the URL will always be "http" or "https".
+* HTTP-specific features such as cookies {{?RFC6265}}, authentication {{?RFC7235}}, caching {{?RFC7234}}, and CORS {{?W3C.REC-cors-20140116}} might or might not work correctly, depending on how they are defined and implemented. Generally, they are designed and implemented with an assumption that the URL will always be "http" or "https".
 
 * Web features that require a secure context {{?W3C.CR-secure-contexts-20160915}} will likely treat a new scheme as insecure.
 


### PR DESCRIPTION
Seems a more general resource than Fetch description of CORS, ignore if you disagree.