### PR TITLE
bcp56bis: Status code reason phrase

### DIFF
--- a/bcp56bis/draft.md
+++ b/bcp56bis/draft.md
@@ -389,9 +389,9 @@ application is harmful, as these are not generic semantics, since the consumer n
 context of the application to understand them.
 
 Furthermore, applications using HTTP MUST NOT re-specify the semantics of HTTP status codes, even
-if it is only by copying their definition. They MUST NOT require specific status phrases to be
-used; the status phrase has no function in HTTP, and is not guaranteed to be preserved by
-implementations.
+if it is only by copying their definition. They MUST NOT require specific reason phrases to be
+used; the reason phrase has no function in HTTP, and is not guaranteed to be preserved by
+implementations. Further, the reason phrase is not conveyable in the HTTP/2 {{?RFC7540}} wire format.
 
 Typically, applications using HTTP will convey application-specific information in the message body
 and/or HTTP header fields, not the status code.


### PR DESCRIPTION
* Replace `status phrase` with `reason phrase` to better align with terms used in RFC 7231 and RFC 7540.
* Add comment that H2 doesn't even define a way to carry the version or reason phrase.