### PR TITLE
Fix unquoted JSON key in draft-nottingham-link-hint-03

### DIFF
--- a/link-hint/draft-nottingham-link-hint-03.xml
+++ b/link-hint/draft-nottingham-link-hint-03.xml
@@ -173,7 +173,7 @@
   "edit-form": {
     "href": "./edit",
     "hints": {
-      formats: {
+      "formats": {
         "application/json": {}
       }
     }


### PR DESCRIPTION
Fixes a typo that yields invalid JSON.