### PR TITLE
Few minor tweaks

### DIFF
--- a/cache-trailers/draft.md
+++ b/cache-trailers/draft.md
@@ -53,9 +53,9 @@ See also the draft's current status in the IETF datatracker, at
 
 # Introduction
 
-Web content that is "dynamically" generated -- i.e., with the response body streamed by the server to the client as it is created -- is often assumed to be uncacheable. In practice, though, there are some scenarios where caching is highly beneficial; for example, when a private cache might be able to reuse a personalised, dynamic response for a period, or when such a response can be shared by a number of clients for a period.
+Web content that is "dynamically" generated -- i.e., with the response body streamed by the server to the client as it is created -- is often assumed to be uncacheable. In practice, though, there are some scenarios where caching is beneficial; for example, when a private cache might be able to reuse a personalised, dynamic response for a period, or when such a response can be shared by a number of clients.
 
-However, a server choosing a caching policy for such a response faces a conundrum: if an error or other unforeseen condition happens during the generation of the response, that caching policy might be too liberal. Currently, the only available solutions are to:
+A server choosing a caching policy for such a response faces a conundrum: if an error or other unforeseen condition happens during the generation of the response, that caching policy might be too liberal. Currently, the only available solutions are to:
 
 1. prevent or severely curtail downstream caching, or
 2. buffer the response until a caching policy can be confidently assigned.
@@ -79,7 +79,7 @@ An HTTP response containing the "trailer-update" cache response directive in its
 
 Upon receiving a Cache-Control field in the trailer section of an eligible response, caches that implement this specification MUST completely replace the stored Cache-Control header field value for that response with the trailer field's value, MUST update its handling of that response to account for the new field value (after any outstanding requests are satisfied), and MUST use that value for the Cache-Control header field in responses to future requests satisfied from that cache entry (i.e., the trailer field is "promoted" to a header field).
 
-In responses where the trailer field value has replaced the heder field value, the "trailer-update" directive will have been removed as part of that process.
+In responses where the trailer field value has replaced the header field value, the "trailer-update" directive will have been removed as part of that process.
 
 Caches MAY temporarily store a response that has a Cache-Control header field with both the "no-store" and "trailer-update" directives, but MUST NOT reuse that response until the caching policy is updated in a manner that allows it. If the caching policy is not updated or the "no-store" directive is still present in the updated response, the cache MUST immediately and permanently discard the temporarily stored response.
 


### PR DESCRIPTION
Just a couple copy edits, otherwise it looks good with a comment...

In the good case, where `trailer-update` is indicated in the header `Cache-Control` but no subsequent trailing `Cache-Control` is provided:

```http-message
HTTP/1.1 200 OK
Content-Type: text/html
Cache-Control: max-age=3600, trailer-update

[body]
```

It says that "Caches that do not implement this specification will cache it by the header policy; caches that do implement will see no updates in the trailer and do the same.", but that means that the `trailer-update` directive does get stored and forwarded on by the cache (since it is never removed). I'm just wanting to make sure there's no unintended down stream consequence from that. We may want to explicitly state that the presence of a `trailer-update`  directive does not *mandate* that a `Cache-Control`  trailer is present.

The only other thing that I can think of is ... when a trailing `Cache-Control` directive is received and it contains an updated timestamp (max-stale, expires, etc) is that calculated from is there any impact on the origin time from which that is calculated. Let's take an extreme example: I start streaming a resource back from the server with a max-age of 30 seconds. 20 seconds later the resource is done streaming and I update the `Cache-Control` with a max-age of 10 seconds.... Is the resource already stale (age calculated from the time the resource started to be received) or is the age calculated from the time the `Cache-Control` was updated and the resource was committed to the cache? Or does that not even matter here.