### PR TITLE
Relax pre-denied to "containing"

### DIFF
--- a/draft-nottingham-httpbis-pre-denied.md
+++ b/draft-nottingham-httpbis-pre-denied.md
@@ -72,7 +72,7 @@ This specification defines a new status code to specifically address this situat
 
 The {{&CODE}} (Preliminary Request Denied) status code indicates that the server is refusing a preliminary request.
 
-A preliminary request is one that contains a Sec-Purpose header field {{FETCH}} with the value "prefetch".
+A preliminary request is one that contains a Sec-Purpose header field {{FETCH}} containing the value "prefetch".
 
 This indication is only applicable to the associated request; future preliminary requests might or might not succeed.
 


### PR DESCRIPTION
A prerender will have a Sec-Purpose of `prefetch;prerender`: https://wicg.github.io/nav-speculation/prerendering.html#interaction-with-fetch

See https://chrome.dev/prerender-demos/ as an example:

<img width="351" height="48" alt="image" src="https://github.com/user-attachments/assets/4d126c76-6c21-42b5-80df-459738c8ef6c" />

So we should not check just for `prefetch` but "containing" `prefetch`. Maybe that's already implied with the current wording but I read it as "exactly matching"? Also feel free to reword it to make it even clearer if you want.